### PR TITLE
Screen shots 1

### DIFF
--- a/blog/Blog.md
+++ b/blog/Blog.md
@@ -482,7 +482,7 @@ In this final part of the tutorial we demonstrate how to use Liberty's Transacti
 
 ### JTA in a CICS Liberty JVM server
 
-In CICS, there is an implicit UOW for every task, so transaction management does not need to be explicitly started. For JTA however, a Container Managed Transaction (CMT) annotation is required on a class or method, or a UserTransaction must be coded with the `begin()` method. A JTA transaction completes at the end of the annotation scope for CMT, or for a `UserTransaction` if the application reaches a U`serTransaction.commit()` or `rollback()`. If no commit or rollback is coded, the Liberty web-container will complete the transaction when the web request terminates.
+In CICS, there is an implicit UOW for every task, so transaction management does not need to be explicitly started. For JTA however, a Container Managed Transaction (CMT) annotation is required on a class or method, or a `UserTransaction` must be coded with the `begin()` method. A JTA transaction completes at the end of the annotation scope for CMT, or for a `UserTransaction` if the application reaches a `UserTransaction.commit()` or `rollback()`. If no commit or rollback is coded, the Liberty web-container will complete the transaction when the web request terminates.
 
 To see a UserTransaction in action, let's create a new class called `JEEUserTransaction.java` as shown below.
 


### PR DESCRIPTION
Added monospace screen shots of CEBR with the latest example output
Actioned all the TODOs
Removed the JVM server deployment info, and just referenced the README (this is the same style we used for the JCICS tutorial)
Moved all the links to references at the end 
Changed the order of the includes in pom.xml and build.gradle to be consistent with the jcics example
Moved the note about restrictions on Task.commit to the start, as it applies to all scenarios