### PR TITLE
Updated Yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           directory: './cics-java-liberty-springboot-transactions-app/'
           file-extensions: '*.java'
-          base-copyright: 'Copyright IBM Corp. 2025'
+          base-copyright: 'Copyright IBM Corp. 2026'
           token: ${{ secrets.GITHUB_TOKEN }}
 
   build-maven:
@@ -98,9 +98,7 @@ jobs:
       with:
         java-version: ${{ matrix.jdk }}
         distribution: 'semeru'
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
-    - name: Build with Gradle
+    - name: Build with Gradle Wrapper
       run: ./gradlew build -Pjava_version=${{ matrix.jdk }}
 
 

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -22,7 +22,7 @@ jobs:
       - id: copyright-action
         uses: cicsdev/.github/.github/actions/samples-copyright-checker@4134522d8109169bb8c460db841f94167ec2802f
         with:
-          directory: './cics-java-liberty-springboot-transactions/'
+          directory: './cics-java-liberty-springboot-transactions-app/'
           file-extensions: '*.java'
           base-copyright: 'Copyright IBM Corp. 2025'
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -79,8 +79,10 @@ jobs:
         distribution: 'semeru'
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
+      with:
+        gradle-version: 8.14.4
     - name: Build with Gradle
-      run: ./gradlew build -Pjava_version=${{ matrix.jdk }}
+      run: gradle build -Pjava_version=${{ matrix.jdk }}
       
   build-gradlew:
     name: Build Gradle wrapper

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # cics-java-liberty-springboot-transactions
-[![Build](https://github.com/cicsdev/cics-java-liberty-springboot-transactions/actions/workflows/java.yaml/badge.svg)](https://github.com/cicsdev/cics-java-liberty-springboot-transactions/actions/workflows/java.yaml)
+[![Build](https://github.com/cicsdev/cics-java-liberty-springboot-transactions/actions/workflows/build.yaml/badge.svg)](https://github.com/cicsdev/cics-java-liberty-springboot-transactions/actions/workflows/build.yaml)
 
 This sample project demonstrates how a Spring Boot application deployed to a Liberty JVM server, can use different techniques to integrate with CICS transactions. The application uses a web browser front end and makes use of the Java™ Transaction API (JTA). The three techniques demonstrated are: Java EE User Transaction, Spring's `@Transactional` annotation, and the Spring Transaction Template. 
 


### PR DESCRIPTION
- Renamed .github/workflows/java.yaml to build.yaml
- Removed setup-gradle action from build-gradlew job
- Wrapper jobs should only use setup-java to validate standalone functionality
- Updated copyright year to 2026
- Aligns with workflow naming standards across CICS sample repositories
- Fixes build failures in Gradle wrapper tests
- Ensure README build badge references the correct (build.yaml) workflow