### PR TITLE
Fix validation issues

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,7 +59,6 @@ jobs:
         with:
           java-version: ${{ matrix.jdk }}
           distribution: "semeru"
-          cache: maven
       - name: Build with Maven
         run: ./mvnw --batch-mode --update-snapshots --file pom.xml -Djava.version=${{ matrix.jdk }} package
 

--- a/.github/workflows/cleanup-old-runs.yml
+++ b/.github/workflows/cleanup-old-runs.yml
@@ -20,5 +20,3 @@ jobs:
           repository: ${{ github.repository }}
           retain_days: 30
           keep_minimum_runs: 3  # Keep at least 3 recent runs of each workflow
-
-# Made with Bob


### PR DESCRIPTION
- Remove cache: maven from build-mvnw job to properly test wrapper standalone

The build-mvnw job should only use setup-java without caching to validate that the Maven wrapper works independently without external dependencies.