### PR TITLE
Add Eclipse project files for submodules and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,7 @@ buildNumber.properties
 .mvn/timing.properties
 
 # Eclipse
-.classpath
-.project
-.settings/
+# Note: .project, .classpath, and .settings/ are committed for multi-module projects
 bin/
 
 # IntelliJ IDEA

--- a/cics-java-liberty-springboot-transactions-app/.classpath
+++ b/cics-java-liberty-springboot-transactions-app/.classpath
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer">
+		<attributes>
+			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path=".apt_generated">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin/default"/>
+</classpath>

--- a/cics-java-liberty-springboot-transactions-app/.project
+++ b/cics-java-liberty-springboot-transactions-app/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>cics-java-liberty-springboot-transactions-app</name>
+	<comment></comment>
+	<projects/>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
+		<nature>org.eclipse.wst.common.modulecore.ModuleCoreNature</nature>
+		<nature>org.eclipse.jem.workbench.JavaEMFNature</nature>
+	</natures>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments/>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.wst.common.project.facet.core.builder</name>
+			<arguments/>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.wst.validation.validationbuilder</name>
+			<arguments/>
+		</buildCommand>
+	</buildSpec>
+	<linkedResources/>
+	<filteredResources/>
+</projectDescription>

--- a/cics-java-liberty-springboot-transactions-app/.settings/org.eclipse.jdt.core.prefs
+++ b/cics-java-liberty-springboot-transactions-app/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,13 @@
+#
+#Tue Jun 16 15:59:47 BST 2026
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=17

--- a/cics-java-liberty-springboot-transactions-app/.settings/org.eclipse.wst.common.component
+++ b/cics-java-liberty-springboot-transactions-app/.settings/org.eclipse.wst.common.component
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-modules id="moduleCoreId" project-version="1.5.0">
+	<wb-module deploy-name="cics-java-liberty-springboot-transactions-app">
+		<property name="context-root" value="cics-java-liberty-springboot-transactions-app"/>
+	</wb-module>
+</project-modules>

--- a/cics-java-liberty-springboot-transactions-app/.settings/org.eclipse.wst.common.project.facet.core.xml
+++ b/cics-java-liberty-springboot-transactions-app/.settings/org.eclipse.wst.common.project.facet.core.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<faceted-project>
+	<fixed facet="jst.java"/>
+	<fixed facet="jst.web"/>
+	<installed facet="jst.web" version="2.4"/>
+	<installed facet="jst.java" version="17"/>
+</faceted-project>

--- a/cics-java-liberty-springboot-transactions-cicsbundle/.project
+++ b/cics-java-liberty-springboot-transactions-cicsbundle/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>cics-java-liberty-springboot-transactions-cicsbundle</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/cics-java-liberty-springboot-transactions-cicsbundle/.settings/org.eclipse.buildship.core.prefs
+++ b/cics-java-liberty-springboot-transactions-cicsbundle/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,13 @@
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
+connection.project.dir=..
+eclipse.preferences.version=1
+gradle.user.home=
+java.home=
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=false
+show.console.view=false
+show.executions.view=false


### PR DESCRIPTION
- Update .gitignore to allow Eclipse project files
- Add .classpath and .project for app submodule
- Add .project for cicsbundle submodule
- Add .settings/ for both submodules
- Ensures clean Eclipse import without manual refresh